### PR TITLE
Ezsms 1047 redirect fix url

### DIFF
--- a/custom_plugins/netlify_redirect.py
+++ b/custom_plugins/netlify_redirect.py
@@ -1,0 +1,19 @@
+import os
+
+from pelican import signals
+
+
+def write_redirects_file(sender):
+    if not "NETLIFY_REDIRECTS" in sender.settings:
+        raise ValueError("NETLIFY_REDIRECTS setting not found in Pelican settings")
+
+    rows = []
+    for from_path, to_path, *options in sender.settings["NETLIFY_REDIRECTS"]:
+        rows.append(" ".join(map(str, [from_path, to_path] + options)))
+
+    with open(os.path.join(sender.output_path, "_redirects"), "w") as f:
+        f.write("\n".join(rows))
+
+
+def register():
+    signals.finalized.connect(write_redirects_file)

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -49,7 +49,7 @@ EXTRA_PATH_METADATA = {
 #THEME           = 'themes/simple'
 THEME           = 'themes/xoxzo'
 PLUGIN_PATHS    = [os.path.join(PROJECT_ROOT, 'plugins'),]
-PLUGINS         = ["i18n_subsites", "subcategory", "more_categories", "tipue_search", "sitemap"]
+PLUGINS         = ["i18n_subsites", "subcategory", "more_categories", "tipue_search", "sitemap", "netlify_redirect"]
 JINJA_ENVIRONMENT = {'extensions': ['jinja2.ext.i18n',]}
 
 DIRECT_TEMPLATES = (('index', 'search'))
@@ -105,3 +105,18 @@ SITEMAP = {
 
 from datetime import date
 CURRENTYEAR = date.today().year
+
+NETLIFY_REDIRECTS = [
+    ("/ja/ezsms-sms-delivery-service/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", 302),
+    ("/ja/ezsms-sms-delivery-service/articles/mobile-number-authentication/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/account/articles/mobile-number-authentication/", 302),
+    ("/ja/ezsms-sms-delivery-service/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", 302),
+    ("/ja/ezsms-sms-delivery-service/articles/how-to-send-with-customised-csv/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms/articles/how-to-send-with-customised-csv/", 302),
+    ("/ja/ezsms-sms-delivery-service/articles/how-many-characters-would-fit-within-1-x-sms/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/how-many-characters-would-fit-within-1-x-sms/", 302),
+    ("/ja/ezsms-sms-delivery-service/articles/can-i-send-sms-to-au-phones-via-c-mail/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/can-i-send-sms-to-au-phones-via-c-mail/", 302),
+    ("/en/ezsms-sms-delivery-service/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", 302),
+    ("/en/ezsms-sms-delivery-service/articles/mobile-number-authentication/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/account/articles/mobile-number-authentication/", 302),
+    ("/en/ezsms-sms-delivery-service/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", 302),
+    ("/en/ezsms-sms-delivery-service/articles/how-to-send-with-customised-csv/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/how-to-send-with-customised-csv/", 302),
+    ("/en/ezsms-sms-delivery-service/articles/how-many-characters-would-fit-within-1-x-sms/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/how-many-characters-would-fit-within-1-x-sms/", 302),
+    ("/en/ezsms-sms-delivery-service/articles/can-i-send-sms-to-au-phones-via-c-mail/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/can-i-send-sms-to-au-phones-via-c-mail/", 302),
+]

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -48,7 +48,7 @@ EXTRA_PATH_METADATA = {
 
 #THEME           = 'themes/simple'
 THEME           = 'themes/xoxzo'
-PLUGIN_PATHS    = [os.path.join(PROJECT_ROOT, 'plugins'),]
+PLUGIN_PATHS    = [os.path.join(PROJECT_ROOT, 'plugins'), os.path.join(PROJECT_ROOT, 'custom_plugins')]
 PLUGINS         = ["i18n_subsites", "subcategory", "more_categories", "tipue_search", "sitemap", "netlify_redirect"]
 JINJA_ENVIRONMENT = {'extensions': ['jinja2.ext.i18n',]}
 
@@ -107,16 +107,16 @@ from datetime import date
 CURRENTYEAR = date.today().year
 
 NETLIFY_REDIRECTS = [
-    ("/ja/ezsms-sms-delivery-service/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", 302),
-    ("/ja/ezsms-sms-delivery-service/articles/mobile-number-authentication/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/account/articles/mobile-number-authentication/", 302),
-    ("/ja/ezsms-sms-delivery-service/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", 302),
-    ("/ja/ezsms-sms-delivery-service/articles/how-to-send-with-customised-csv/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms/articles/how-to-send-with-customised-csv/", 302),
-    ("/ja/ezsms-sms-delivery-service/articles/how-many-characters-would-fit-within-1-x-sms/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/how-many-characters-would-fit-within-1-x-sms/", 302),
-    ("/ja/ezsms-sms-delivery-service/articles/can-i-send-sms-to-au-phones-via-c-mail/", "https://help.xoxzo.com/ja/ezsms-sms-delivery-service/sms-api/articles/can-i-send-sms-to-au-phones-via-c-mail/", 302),
-    ("/en/ezsms-sms-delivery-service/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", 302),
-    ("/en/ezsms-sms-delivery-service/articles/mobile-number-authentication/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/account/articles/mobile-number-authentication/", 302),
-    ("/en/ezsms-sms-delivery-service/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", 302),
-    ("/en/ezsms-sms-delivery-service/articles/how-to-send-with-customised-csv/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/how-to-send-with-customised-csv/", 302),
-    ("/en/ezsms-sms-delivery-service/articles/how-many-characters-would-fit-within-1-x-sms/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/how-many-characters-would-fit-within-1-x-sms/", 302),
-    ("/en/ezsms-sms-delivery-service/articles/can-i-send-sms-to-au-phones-via-c-mail/", "https://help.xoxzo.com/en/ezsms-sms-delivery-service/sms-api/articles/can-i-send-sms-to-au-phones-via-c-mail/", 302),
+    ("/ja/ezsms-sms-delivery-service/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", "/ja/ezsms-sms-delivery-service/sms-api/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/"),
+    ("/ja/ezsms-sms-delivery-service/articles/mobile-number-authentication/", "/ja/ezsms-sms-delivery-service/account/articles/mobile-number-authentication/"),
+    ("/ja/ezsms-sms-delivery-service/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", "/ja/ezsms-sms-delivery-service/sms-api/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/"),
+    ("/ja/ezsms-sms-delivery-service/articles/how-to-send-with-customised-csv/", "/ja/ezsms-sms-delivery-service/sms/articles/how-to-send-with-customised-csv/"),
+    ("/ja/ezsms-sms-delivery-service/articles/how-many-characters-would-fit-within-1-x-sms/", "/ja/ezsms-sms-delivery-service/sms-api/articles/how-many-characters-would-fit-within-1-x-sms/"),
+    ("/ja/ezsms-sms-delivery-service/articles/can-i-send-sms-to-au-phones-via-c-mail/", "/ja/ezsms-sms-delivery-service/sms-api/articles/can-i-send-sms-to-au-phones-via-c-mail/"),
+    ("/en/ezsms-sms-delivery-service/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/", "/en/ezsms-sms-delivery-service/sms-api/articles/what-are-the-variables-that-i-can-use-for-return-sms-with-dialsms/"),
+    ("/en/ezsms-sms-delivery-service/articles/mobile-number-authentication/", "/en/ezsms-sms-delivery-service/account/articles/mobile-number-authentication/"),
+    ("/en/ezsms-sms-delivery-service/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/", "/en/ezsms-sms-delivery-service/sms-api/articles/what-will-be-displayed-as-senderid-of-the-dialsms-message/"),
+    ("/en/ezsms-sms-delivery-service/articles/how-to-send-with-customised-csv/", "/en/ezsms-sms-delivery-service/sms-api/articles/how-to-send-with-customised-csv/"),
+    ("/en/ezsms-sms-delivery-service/articles/how-many-characters-would-fit-within-1-x-sms/", "/en/ezsms-sms-delivery-service/sms-api/articles/how-many-characters-would-fit-within-1-x-sms/"),
+    ("/en/ezsms-sms-delivery-service/articles/can-i-send-sms-to-au-phones-via-c-mail/", "/en/ezsms-sms-delivery-service/sms-api/articles/can-i-send-sms-to-au-phones-via-c-mail/"),
 ]


### PR DESCRIPTION
Some of the links are also called from different source not only from ezsms site but also from internal help xoxzo itself. This is to PR is to redirect broken URLs to corrected urls:

- [x] Add custom plugins redirects netlify
- [x] Add redirects rules

It will generate `_redirects` file like this:
<img width="1613" alt="Screenshot 2023-06-20 at 13 26 18" src="https://github.com/xoxzo/help.xoxzo.com/assets/23071425/6c914873-6b09-4ca0-9949-2bf0dac044e8">

References:
https://docs.netlify.com/routing/redirects/


